### PR TITLE
fix python:3.4-alpine docker-compose up fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-alpine
+FROM python:3.6-alpine
 ADD . /code
 WORKDIR /code
 RUN pip install -r requirements.txt


### PR DESCRIPTION
python:3.4-alpine version docker-compose up fail, 
Will report "/bin/sh -c pip install  returned a non-zero code" error.
Change to python:3.6-alpine version, it will compose up success.